### PR TITLE
dev(narugo): add convert function from embeddings to understandable result of taggers

### DIFF
--- a/docs/source/api_doc/tagging/wd14.rst
+++ b/docs/source/api_doc/tagging/wd14.rst
@@ -12,3 +12,11 @@ get_wd14_tags
 .. autofunction:: get_wd14_tags
 
 
+
+convert_wd14_emb_to_prediction
+----------------------------------------------
+
+.. autofunction:: convert_wd14_emb_to_prediction
+
+
+

--- a/docs/source/api_doc/utils/func.rst
+++ b/docs/source/api_doc/utils/func.rst
@@ -1,0 +1,14 @@
+imgutils.utils.func
+====================================
+
+.. currentmodule:: imgutils.utils.func
+
+.. automodule:: imgutils.utils.func
+
+
+sigmoid
+-------------------------
+
+.. autofunction:: sigmoid
+
+

--- a/docs/source/api_doc/utils/index.rst
+++ b/docs/source/api_doc/utils/index.rst
@@ -9,4 +9,5 @@ imgutils.utils
 .. toctree::
     :maxdepth: 3
 
+    func
     onnxruntime

--- a/imgutils/tagging/__init__.py
+++ b/imgutils/tagging/__init__.py
@@ -16,4 +16,4 @@ from .match import tag_match_suffix, tag_match_prefix, tag_match_full
 from .mldanbooru import get_mldanbooru_tags
 from .order import sort_tags
 from .overlap import drop_overlap_tags
-from .wd14 import get_wd14_tags
+from .wd14 import get_wd14_tags, convert_wd14_emb_to_prediction

--- a/imgutils/tagging/wd14.py
+++ b/imgutils/tagging/wd14.py
@@ -298,13 +298,23 @@ def get_wd14_tags(
         - ``embedding``: a 1-dim embedding of image, recommended for index building after L2 normalization
         - ``prediction``: a 1-dim prediction result of image
 
+        You can extract embedding of the given image with the follwing code
+
+        >>> from imgutils.tagging import get_wd14_tags
+        >>>
+        >>> embedding = get_wd14_tags('skadi.jpg', fmt='embdding')
+        >>> embedding.shape
+        (1024, )
+
+        This embedding is valuable for constructing indices that enable rapid querying of images based on
+        visual features within large-scale datasets.
+
     Example:
         Here are some images for example
 
         .. image:: tagging_demo.plot.py.svg
            :align: center
 
-        >>> import os
         >>> from imgutils.tagging import get_wd14_tags
         >>>
         >>> rating, features, chars = get_wd14_tags('skadi.jpg')

--- a/imgutils/utils/__init__.py
+++ b/imgutils/utils/__init__.py
@@ -4,6 +4,7 @@ Overview:
 """
 from .area import *
 from .format import *
+from .func import *
 from .onnxruntime import *
 from .storage import *
 from .tqdm_ import *

--- a/imgutils/utils/func.py
+++ b/imgutils/utils/func.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+__all__ = ['sigmoid']
+
+
+def sigmoid(x):
+    return 1 / (1 + np.exp(-x))

--- a/imgutils/utils/func.py
+++ b/imgutils/utils/func.py
@@ -1,7 +1,42 @@
+"""
+This module provides mathematical functions related to neural networks.
+
+It includes the sigmoid activation function, which is commonly used in various
+machine learning and deep learning models. The sigmoid function maps any input
+value to a value between 0 and 1, making it useful for binary classification
+problems and as an activation function in neural network layers.
+
+Usage:
+    >>> from imgutils.utils import sigmoid
+    >>> result = sigmoid(input_value)
+"""
+
 import numpy as np
 
 __all__ = ['sigmoid']
 
 
 def sigmoid(x):
+    """
+    Compute the sigmoid function for the input.
+
+    The sigmoid function is defined as:
+    :math:`f\\left(x\\right) = \\frac{1}{1 + e^{-x}}`
+
+    This function applies the sigmoid activation to either a single number
+    or an array of numbers using NumPy for efficient computation.
+
+    :param x: Input value or array of values.
+    :type x: float or numpy.ndarray
+
+    :return: Sigmoid of the input.
+    :rtype: float or numpy.ndarray
+
+    :example:
+        >>> import numpy as np
+        >>> sigmoid(0)
+        0.5
+        >>> sigmoid(np.array([-1, 0, 1]))
+        array([0.26894142, 0.5       , 0.73105858])
+    """
     return 1 / (1 + np.exp(-x))

--- a/test/tagging/test_wd14.py
+++ b/test/tagging/test_wd14.py
@@ -1,6 +1,6 @@
 import pytest
 
-from imgutils.tagging import get_wd14_tags
+from imgutils.tagging import get_wd14_tags, convert_wd14_emb_to_prediction
 from imgutils.tagging.wd14 import _get_wd14_model
 from test.testings import get_testfile
 
@@ -159,3 +159,17 @@ class TestTaggingWd14:
             'tube_top': 0.9783295392990112, 'bead_bracelet': 0.3510066270828247, 'red_bandeau': 0.8741766214370728
         }, abs=2e-2)
         assert chars == pytest.approx({'nian_(arknights)': 0.9968841671943665}, abs=2e-2)
+
+    @pytest.mark.parametrize(['file'], [
+        ('nude_girl.png',),
+        ('nian.png',),
+    ])
+    def test_convert_wd14_emb_to_prediction(self, file):
+        file = get_testfile(file)
+        (expected_rating, expected_general, expected_character), embedding = \
+            get_wd14_tags(file, fmt=(('rating', 'general', 'character'), 'embedding'))
+
+        rating, general, character = convert_wd14_emb_to_prediction(embedding)
+        assert rating == pytest.approx(expected_rating, abs=2e-3)
+        assert general == pytest.approx(expected_general, abs=2e-3)
+        assert character == pytest.approx(expected_character, abs=2e-3)

--- a/test/utils/test_func.py
+++ b/test/utils/test_func.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+from imgutils.utils import sigmoid
+
+
+@pytest.fixture
+def sample_input():
+    return np.array([-1, 0, 1])
+
+
+@pytest.fixture
+def expected_output():
+    return np.array([0.26894142, 0.5, 0.73105858])
+
+
+@pytest.mark.unittest
+class TestUtilsFuncSigmoid:
+    def test_sigmoid_scalar(self):
+        assert np.isclose(sigmoid(0), 0.5)
+
+    def test_sigmoid_array(self, sample_input, expected_output):
+        result = sigmoid(sample_input)
+        np.testing.assert_array_almost_equal(result, expected_output)
+
+    def test_sigmoid_large_positive(self):
+        assert np.isclose(sigmoid(100), 1.0)
+
+    def test_sigmoid_large_negative(self):
+        assert np.isclose(sigmoid(-100), 0.0)
+
+    def test_sigmoid_zero(self):
+        assert sigmoid(0) == 0.5
+
+    def test_sigmoid_type(self):
+        assert isinstance(sigmoid(1), float)
+        assert isinstance(sigmoid(np.array([1])), np.ndarray)
+
+    def test_sigmoid_shape(self):
+        input_array = np.array([[1, 2], [3, 4]])
+        result = sigmoid(input_array)
+        assert result.shape == input_array.shape


### PR DESCRIPTION
```python
from pprint import pprint

from imgutils.tagging import get_wd14_tags, convert_wd14_emb_to_prediction
from test.testings import get_testfile

embedding = get_wd14_tags(get_testfile('nude_girl.png'), fmt='embedding')

rating, general, character = convert_wd14_emb_to_prediction(embedding)
pprint(rating)
print(general)
print(character)

```