### PR TITLE
dev(narugo): do not use shapely 2.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas
 scipy
 emoji>=2.5.0,<2.12
 pilmoji>=1.3.0
-shapely
+shapely!=2.0.7
 pyclipper
 deprecation>=2.0.0
 hfutils>=0.4.2


### PR DESCRIPTION
no pre-compiled wheels found in shapely 2.0.7: https://github.com/shapely/shapely/issues/2208

so do not use this version